### PR TITLE
convert standard .jscsrc to eslint using polyjuice.

### DIFF
--- a/main.json
+++ b/main.json
@@ -83,10 +83,7 @@
             "always-multiline"
         ],
         "comma-spacing": "error",
-        "comma-style": [
-            "error",
-            "last"
-        ],
+        "comma-style": "error",
         "computed-property-spacing": "error",
         "eol-last": "error",
         "func-call-spacing": "error",

--- a/main.json
+++ b/main.json
@@ -68,16 +68,25 @@
         "no-use-before-define": "error",
         "array-bracket-spacing": [
             "error",
-            "never"
+            "always"
         ],
         "block-spacing": "error",
-        "brace-style": "error",
+        "brace-style": [
+            "error",
+            "1tbs",
+            {
+                "allowSingleLine": true
+            }
+        ],
         "comma-dangle": [
             "error",
             "always-multiline"
         ],
         "comma-spacing": "error",
-        "comma-style": "error",
+        "comma-style": [
+            "error",
+            "last"
+        ],
         "computed-property-spacing": "error",
         "eol-last": "error",
         "func-call-spacing": "error",
@@ -88,7 +97,13 @@
                 "SwitchCase": 1
             }
         ],
-        "key-spacing": "error",
+        "key-spacing": [
+            "error",
+            {
+                "beforeColon": false,
+                "afterColon": true
+            }
+        ],
         "line-comment-position": "error",
         "new-parens": "error",
         "no-inline-comments": "error",
@@ -122,6 +137,58 @@
 
         "no-template-curly-in-string": 1,
         "import/named": 2,
-        "radix": 0
+        "radix": 0,
+        "keyword-spacing": [
+            "error",
+            {
+                "overrides": {},
+                "before": true
+            }
+        ],
+        "wrap-iife": "error",
+        "space-before-function-paren": [
+            "error",
+            "always"
+        ],
+        "one-var": [
+            "error",
+            "never"
+        ],
+        "no-empty": [
+            "error",
+            {
+                "allowEmptyCatch": true
+            }
+        ],
+        "quote-props": [
+            "error",
+            "as-needed"
+        ],
+        "operator-linebreak": [
+            "error",
+            "after"
+        ],
+        "space-unary-ops": [
+            "error",
+            {
+                "words": false,
+                "nonwords": false
+            }
+        ],
+        "space-infix-ops": "error",
+        "no-multi-str": "error",
+        "no-multiple-empty-lines": "error",
+        "yoda": [
+            "error",
+            "never"
+        ],
+        "spaced-comment": [
+            "error",
+            "always"
+        ],
+        "func-style": [
+            "error",
+            "expression"
+        ]
     }
 }

--- a/main.json
+++ b/main.json
@@ -68,7 +68,7 @@
         "no-use-before-define": "error",
         "array-bracket-spacing": [
             "error",
-            "always"
+            "never"
         ],
         "block-spacing": "error",
         "brace-style": [

--- a/main.json
+++ b/main.json
@@ -94,13 +94,7 @@
                 "SwitchCase": 1
             }
         ],
-        "key-spacing": [
-            "error",
-            {
-                "beforeColon": false,
-                "afterColon": true
-            }
-        ],
+        "key-spacing": "error",
         "line-comment-position": "error",
         "new-parens": "error",
         "no-inline-comments": "error",

--- a/main.json
+++ b/main.json
@@ -75,7 +75,7 @@
             "error",
             "1tbs",
             {
-                "allowSingleLine": true
+                "allowSingleLine": false
             }
         ],
         "comma-dangle": [

--- a/main.json
+++ b/main.json
@@ -189,6 +189,7 @@
         "func-style": [
             "error",
             "expression"
-        ]
+        ],
+        "new-cap": "error"
     }
 }


### PR DESCRIPTION
@incuna/js 

https://www.npmjs.com/package/polyjuice

The following were not translated according to the tool:
```
requireSpacesInConditionalExpression
requireBlocksOnNewline
requireCapitalizedConstructors
disallowNewlineBeforeBlockStatements
validateParameterSeparator
```

`requireSpacesInConditionalExpression`
becomes space-infix-ops

`requireBlocksOnNewline` 
approximately equal to `brace-style: [2, "1tbs"]` which exists in the code

`requireCapitalizedConstructors` 
http://jscs.info/rule/requireCapitalizedConstructors i have added as http://eslint.org/docs/rules/new-cap

`disallowNewlineBeforeBlockStatements`
covered by `brace-style`
http://jscs.info/rule/disallowNewlineBeforeBlockStatements http://eslint.org/docs/rules/brace-style.html

`validateParameterSeparator`
covered by http://eslint.org/docs/rules/comma-spacing