### PR TITLE
Allow newlines in objects of 1 or 2 properties

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -2,6 +2,10 @@
 
 This project uses Semantic Versioning (2.0).
 
+# Upcoming
+
+* Allow newlines in objects of 1 or 2 properties, so long as the newlines are consistent
+
 ## 1.1.0
 
 * Update to included old JSCS checks

--- a/main.json
+++ b/main.json
@@ -106,10 +106,12 @@
             "error", {
                 "ObjectExpression": {
                     "minProperties": 3,
-                    "multiline": true
+                    "multiline": true,
+                    "consistent": true
                 },
                 "ObjectPattern": {
-                    "multiline": true
+                    "multiline": true,
+                    "consistent": true
                 }
             }
         ],

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
   },
   "homepage": "https://github.com/incuna/eslint-config-incuna#readme",
   "peerDependencies": {
-    "eslint": ">= 3",
+    "eslint": ">= 4",
     "eslint-plugin-import": ">= 2"
   }
 }


### PR DESCRIPTION
Use new eslint v4 `consistent` option of `object-curly-newline` rule.
See https://github.com/eslint/eslint/commit/b337738f50bdd2ea732172de3ed7036fc1879c83

@maxpeterson @Minglee01 Please merge, ta!